### PR TITLE
🗃️ review와 user의 id를 int형으로 변경

### DIFF
--- a/prisma/migrations/20241005040719_change_uuid_to_just_int/migration.sql
+++ b/prisma/migrations/20241005040719_change_uuid_to_just_int/migration.sql
@@ -1,0 +1,75 @@
+/*
+  Warnings:
+
+  - The primary key for the `event` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `event` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `user` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `user` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `host_id` on the `event` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `event_id` on the `event_join` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `event_join` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `event_id` on the `review` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `user_id` on the `review` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "event" DROP CONSTRAINT "event_host_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "event_join" DROP CONSTRAINT "event_join_event_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "event_join" DROP CONSTRAINT "event_join_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "review" DROP CONSTRAINT "review_event_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "review" DROP CONSTRAINT "review_user_id_fkey";
+
+-- AlterTable
+ALTER TABLE "event" DROP CONSTRAINT "event_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+DROP COLUMN "host_id",
+ADD COLUMN     "host_id" INTEGER NOT NULL,
+ADD CONSTRAINT "event_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "event_join" DROP COLUMN "event_id",
+ADD COLUMN     "event_id" INTEGER NOT NULL,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "review" DROP COLUMN "event_id",
+ADD COLUMN     "event_id" INTEGER NOT NULL,
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "user" DROP CONSTRAINT "user_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "user_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "event_join_event_id_user_id_key" ON "event_join"("event_id", "user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "review_event_id_user_id_key" ON "review"("event_id", "user_id");
+
+-- AddForeignKey
+ALTER TABLE "event" ADD CONSTRAINT "event_host_id_fkey" FOREIGN KEY ("host_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "event_join" ADD CONSTRAINT "event_join_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "event"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "event_join" ADD CONSTRAINT "event_join_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "review" ADD CONSTRAINT "review_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "event"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "review" ADD CONSTRAINT "review_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,7 +14,7 @@ datasource db {
 }
 
 model User {
-  id        String    @id @default(uuid())
+  id        Int       @id @default(autoincrement())
   cityId    Int?      @map("city_id")
   name      String
   email     String    @unique
@@ -44,8 +44,8 @@ model Category {
 }
 
 model Event {
-  id          String   @id @default(uuid())
-  hostId      String   @map("host_id")
+  id          Int      @id @default(autoincrement())
+  hostId      Int      @map("host_id")
   categoryId  Int      @map("category_id")
   cityId      Int      @map("city_id")
   title       String
@@ -68,8 +68,8 @@ model Event {
 
 model EventJoin {
   id        Int      @id @default(autoincrement())
-  eventId   String   @map("event_id")
-  userId    String   @map("user_id")
+  eventId   Int      @map("event_id")
+  userId    Int      @map("user_id")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
@@ -82,8 +82,8 @@ model EventJoin {
 
 model Review {
   id          Int      @id @default(autoincrement())
-  eventId     String   @map("event_id")
-  userId      String   @map("user_id")
+  eventId     Int      @map("event_id")
+  userId      Int      @map("user_id")
   title       String
   score       Int
   description String?


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- review와 user를 id를 uuid에서 int형 auto_increment로 변경합니다.


## Why
- 기존 스키마에서 review와 user의 id는 uuid로 생성하는 string이었습니다.
- Web Client가 사용 시 Url에 노출될 염려가 있는 자원의 ID는 보안 차원에서 uuid를 사용하는 것을 선호하는 편이라 처음에 uuid로 설정했습니다만, 연습용 레포에서는 사용하기가 까다롭고 익숙하지 않은 분들이 많을 듯 하여 int형으로 다시 돌리는 작업입니다.


## Checklist
- 모두 `db:save:dev` 한번이랑 `prisma generate` 한번 하고 가시면 됩니다!